### PR TITLE
Original inset can be loosed

### DIFF
--- a/TPKeyboardAvoidingScrollView.h
+++ b/TPKeyboardAvoidingScrollView.h
@@ -7,6 +7,7 @@
 
 @interface TPKeyboardAvoidingScrollView : UIScrollView {
     UIEdgeInsets    _priorInset;
+    BOOL            _priorInsetSaved;
     BOOL            _keyboardVisible;
     CGRect          _keyboardRect;
     CGSize          _originalContentSize;

--- a/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoidingScrollView.m
@@ -19,6 +19,7 @@
 @implementation TPKeyboardAvoidingScrollView
 
 - (void)setup {
+    _priorInsetSaved = NO;
     if ( CGSizeEqualToSize(self.contentSize, CGSizeZero) ) {
         self.contentSize = self.bounds.size;
     }
@@ -81,7 +82,10 @@
         return;
     }
     
-    _priorInset = self.contentInset;
+    if (!_priorInsetSaved) {
+        _priorInset = self.contentInset;
+        _priorInsetSaved = YES;
+    }
     
     // Shrink view's inset by the keyboard's height, and scroll to show the text field/view being edited
     [UIView beginAnimations:nil context:NULL];
@@ -105,6 +109,7 @@
     [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
     [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
     self.contentInset = _priorInset;
+    _priorInsetSaved = NO;
     [UIView commitAnimations];
 }
 

--- a/TPKeyboardAvoidingTableView.h
+++ b/TPKeyboardAvoidingTableView.h
@@ -7,6 +7,7 @@
 
 @interface TPKeyboardAvoidingTableView : UITableView {
     UIEdgeInsets    _priorInset;
+    BOOL            _priorInsetSaved;
     BOOL            _keyboardVisible;
     CGRect          _keyboardRect;
 }

--- a/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoidingTableView.m
@@ -83,7 +83,10 @@
         return;
     }
     
-    _priorInset = self.contentInset;
+    if (!_priorInsetSaved) {
+        _priorInset = self.contentInset;
+        _priorInsetSaved = YES;
+    }
     
     // Shrink view's inset by the keyboard's height, and scroll to show the text field/view being edited
     [UIView beginAnimations:nil context:NULL];
@@ -107,6 +110,7 @@
     [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
     [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
     self.contentInset = _priorInset;
+    _priorInsetSaved = NO;
     [UIView commitAnimations];
 }
 


### PR DESCRIPTION
When the user pass from on textfield to another one directly, no keyboard events are called.
But if those two textfields haven't the same type of input view (for instance, one with the default keyboard and one with a custom view) so only a KeyBoardWillShow event is thrown (it isn't balanced with a KeyBoardWillHide) and then the _priorInset will saved the current inset which is the modified one (not the original one).
Tell me if you want a sample code.
