### PR TITLE
Remove a call to [super dealloc]

### DIFF
--- a/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoidingScrollView.m
@@ -39,7 +39,7 @@
 
 -(void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [super dealloc];
+//    [super dealloc];
 }
 
 -(void)setFrame:(CGRect)frame {


### PR DESCRIPTION
Xcode was complaining about this additional call in the dealloc method.  Wasn't sure it was the right decision until I read this:

http://clang.llvm.org/docs/AutomaticReferenceCounting.html#misc.special_methods.dealloc

Adding a dealloc to a subclass is apparently find, but calling the super class's dealloc is not allowed.
