### PR TITLE
Scrollview offset when hiding keyboard

### DIFF
--- a/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoidingScrollView.m
@@ -112,6 +112,7 @@
     [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
     [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
     self.contentInset = _priorInset;
+    self.contentOffset = CGPointZero;
     [self setScrollIndicatorInsets:self.contentInset];
     _priorInsetSaved = NO;
     [UIView commitAnimations];


### PR DESCRIPTION
Sometimes the ViewController is not full screen (because it is contained in another ViewController). I found out that if it's small enough, the content needs to scroll when the keyboard appears, but it is not scrolled back when it disappears. The result is a white band on the bottom of the ViewController.

This patch fixes it.
