### PR TITLE
Andrew Hill: Add support for initWithFrame: style:

### DIFF
--- a/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoidingTableView.m
@@ -43,6 +43,8 @@
     if ( !(self = [super initWithFrame:frame style:withStyle]) ) return nil;
     [self setup];
 return self;
+}
+
 -(void)awakeFromNib {
     [self setup];
 }


### PR DESCRIPTION
Added support for initWithFrame: style: to UITableView (the current code will otherwise fail on attempts to create grouped tables, or to create the default table style but using the full init syntax).

NB Grouped tables whilst now supported aren't displayed optimally - they probably need to account for gaps between sections and section headers.
