### PR TITLE
Fixed scrollview "jumping" issue when keyboard is dismissed.

### DIFF
--- a/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoidingScrollView.m
@@ -179,8 +179,6 @@
     CGPoint idealOffset = CGPointMake(0, [self idealOffsetForView:[self findFirstResponderBeneathView:self] withSpace:visibleSpace]);
     
     [self setContentOffset:idealOffset animated:YES];
-    
-    _originalContentOffset = self.contentOffset;
 }
 
 #pragma mark - Helpers


### PR DESCRIPTION
When focusing a UITextField, then subsequently another UITextField either by tapping it, or using the new "Next" button - the UIScrollView's _originalContentOffset was being updated incorrectly.
