### PR TITLE
Table View Keyboard extra space

### DIFF
--- a/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoidingTableView.m
@@ -91,47 +91,51 @@
 - (void)keyboardWillShow:(NSNotification*)notification {
     _keyboardRect = [[[notification userInfo] objectForKey:_UIKeyboardFrameEndUserInfoKey] CGRectValue];
     _keyboardVisible = YES;
-    
-    UIView *firstResponder = [self findFirstResponderBeneathView:self];
-    if ( !firstResponder ) {
-        // No child view is the first responder - nothing to do here
-        return;
-    }
-    
-    _originalContentOffset = self.contentOffset;
-    
-    if (!_priorInsetSaved) {
-        _priorInset = self.contentInset;
-        _priorInsetSaved = YES;
-    }
-    
-    // Shrink view's inset by the keyboard's height, and scroll to show the text field/view being edited
-    [UIView beginAnimations:nil context:NULL];
-    [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
-    [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
-    
-    self.contentInset = [self contentInsetForKeyboard];
-    [self setContentOffset:CGPointMake(self.contentOffset.x,
-                                       [self idealOffsetForView:firstResponder withSpace:[self keyboardRect].origin.y - self.bounds.origin.y])
-                  animated:YES];
-    [self setScrollIndicatorInsets:self.contentInset];
-    
-    [UIView commitAnimations];
+	
+	if ([[[UIDevice currentDevice] systemVersion] floatValue] < 5.0) {
+		UIView *firstResponder = [self findFirstResponderBeneathView:self];
+		if ( !firstResponder ) {
+			// No child view is the first responder - nothing to do here
+			return;
+		}
+		
+		_originalContentOffset = self.contentOffset;
+		
+		if (!_priorInsetSaved) {
+			_priorInset = self.contentInset;
+			_priorInsetSaved = YES;
+		}
+		
+		// Shrink view's inset by the keyboard's height, and scroll to show the text field/view being edited
+		[UIView beginAnimations:nil context:NULL];
+		[UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
+		[UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
+		
+		self.contentInset = [self contentInsetForKeyboard];
+		[self setContentOffset:CGPointMake(self.contentOffset.x,
+										   [self idealOffsetForView:firstResponder withSpace:[self keyboardRect].origin.y - self.bounds.origin.y])
+					  animated:YES];
+		[self setScrollIndicatorInsets:self.contentInset];
+		
+		[UIView commitAnimations];
+	}
 }
 
 - (void)keyboardWillHide:(NSNotification*)notification {
     _keyboardRect = CGRectZero;
     _keyboardVisible = NO;
     
-    // Restore dimensions to prior size
-    [UIView beginAnimations:nil context:NULL];
-    [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
-    [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
-    self.contentInset = _priorInset;
-    self.contentOffset = _originalContentOffset;
-    [self setScrollIndicatorInsets:self.contentInset];
-    _priorInsetSaved = NO;
-    [UIView commitAnimations];
+	if ([[[UIDevice currentDevice] systemVersion] floatValue] < 5.0) {
+		// Restore dimensions to prior size
+		[UIView beginAnimations:nil context:NULL];
+		[UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
+		[UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
+		self.contentInset = _priorInset;
+		self.contentOffset = _originalContentOffset;
+		[self setScrollIndicatorInsets:self.contentInset];
+		_priorInsetSaved = NO;
+		[UIView commitAnimations];
+	}
 }
 
 -(BOOL)textFieldShouldReturn:(UITextField *)textField {


### PR DESCRIPTION
Fixed issue with the table view where when the keyboard is active there
is too much space and when the keyboard is closed you can't always get
to the bottom of the table view.  
This happens in a navigation controller when you go to another page and then back the contentInset gets changed causing this extra whitespace with the keyboard up.  I looked into what was causing the contentInset issue and I couldn't find anything in the code so it is most likely in the tableview controller.  Removing the animation for the keyboard showing and disappearing fixed the issue.  I tested in iOS 5 to iOS 6 and the table view handles the scaling of the view however I don't have iOS 4.3 any more so I was unable to test on that platform
