### PR TITLE
Added button that allows people get built application in their devices from browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@ TPKeyboardAvoiding
 ==================
 
 A drop-in universal solution for moving text fields out of the way of the keyboard in iOS.
+<!-- MacBuildServer Install Button -->
+<div class="macbuildserver-block">
+    <a class="macbuildserver-button" href="http://macbuildserver.com/project/github/build/?xcode_project=TPKeyboardAvoidingSample.xcodeproj&amp;target=TPKeyboardAvoidingSample&amp;repo_url=https%3A%2F%2Fgithub.com%2Fmichaeltyson%2FTPKeyboardAvoiding&amp;build_conf=Release" target="_blank"><img src="http://com.macbuildserver.github.s3-website-us-east-1.amazonaws.com/button_up.png"/></a><br/><sup><a href="http://macbuildserver.com/github/opensource/" target="_blank">by MacBuildServer</a></sup>
+</div>
+<!-- MacBuildServer Install Button -->
 
 Introduction
 ------------


### PR DESCRIPTION
Hey,

I've added 'Install app' button into your README file. Anyone could try your sample application right in browser. Look how it's working!

To learn more, please look at: http://macbuildserver.com/github/opensource/
