### PR TITLE
Added property that lets you auto adjust the contentSize to the bounds

### DIFF
--- a/TPKeyboardAvoidingScrollView.h
+++ b/TPKeyboardAvoidingScrollView.h
@@ -8,6 +8,7 @@
 #import <UIKit/UIKit.h>
 
 @interface TPKeyboardAvoidingScrollView : UIScrollView
+@property (assign, nonatomic) BOOL autoAdjustsContentSizeToBounds;
 - (BOOL)focusNextTextField;
 - (void)scrollToActiveTextField;
 @end

--- a/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoidingScrollView.m
@@ -64,6 +64,12 @@
     [self handleContentSize];
 }
 
+-(void)setAutoAdjustsContentSizeToBounds:(BOOL)autoAdjustsContentSizeToBounds {
+    _autoAdjustsContentSizeToBounds = autoAdjustsContentSizeToBounds;
+    
+    [self handleContentSize];
+}
+
 #pragma mark - Responders, events
 
 - (void) touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
@@ -167,7 +173,7 @@
 #pragma mark - Helpers
 
 -(void)handleContentSize {
-    CGSize contentSize = _originalContentSize;
+    CGSize contentSize = _autoAdjustsContentSizeToBounds ? self.bounds.size : _originalContentSize;
     contentSize.width = MAX(contentSize.width, self.frame.size.width);
     contentSize.height = MAX(contentSize.height, self.frame.size.height);
     [super setContentSize:contentSize];


### PR DESCRIPTION
Sometimes your scrollView's frame will change, e.g. if your view controller's view moves into a UINavigationController or a UITabBarController. And if you laid out your view in IB, you might want the contentSize to match the bounds, after they've changed, because that's how you designed the view. Sometimes you use a scrollView to show more than would fit on screen, and sometimes you use it just so you can move your view out of the way of the keyboard. This addresses the case where the entire view fits in the viewport, and you're using a scrollView just to move your UI away from the keyboard. 

This property (defaults to NO) allows the contentSize to change automatically in response to when the bounds change.
