### PR TITLE
Fixes an issue that could appear, when you put multiple scroll views on ...

### DIFF
--- a/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoidingScrollView.m
@@ -60,6 +60,7 @@ const CGFloat kCalculatedContentPadding = 10;
 -(void)setContentSize:(CGSize)contentSize {
     [super setContentSize:contentSize];
     if ( _keyboardVisible ) {
+		_priorContentSize = self.contentSize;
         self.contentInset = [self contentInsetForKeyboard];
     }
 }


### PR DESCRIPTION
...top of each other

Creating multiple scroll views on top of each other could lead to an issue, where UIKeyboard notifications would arrive out of order. This lead to the lowest scroll view setting its contentSize back to (0, 0), because _priorContentSize was never set. This should fix that problem
