### PR TITLE
Previous code set scrollIndicatorInsets to _priorInset when keyboard dis...

### DIFF
--- a/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoidingScrollView.m
@@ -13,6 +13,7 @@ const CGFloat kCalculatedContentPadding = 10;
 
 @interface TPKeyboardAvoidingScrollView () <UITextFieldDelegate, UITextViewDelegate> {
     UIEdgeInsets    _priorInset;
+    UIEdgeInsets    _priorScrollIndicatorInsets;
     BOOL            _keyboardVisible;
     CGRect          _keyboardRect;
     CGSize          _contentsSize;
@@ -92,6 +93,7 @@ const CGFloat kCalculatedContentPadding = 10;
     }
     
     _priorInset = self.contentInset;
+    _priorScrollIndicatorInsets = self.scrollIndicatorInsets;
     _priorContentSize = self.contentSize;
     
     // Shrink view's inset by the keyboard's height, and scroll to show the text field/view being edited
@@ -121,7 +123,7 @@ const CGFloat kCalculatedContentPadding = 10;
     [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
     self.contentSize = _priorContentSize;
     self.contentInset = _priorInset;
-    [self setScrollIndicatorInsets:self.contentInset];
+    self.scrollIndicatorInsets = _priorScrollIndicatorInsets;
     [UIView commitAnimations];
 }
 

--- a/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoidingTableView.m
@@ -11,6 +11,7 @@
 
 @interface TPKeyboardAvoidingTableView () <UITextFieldDelegate, UITextViewDelegate> {
     UIEdgeInsets    _priorInset;
+    UIEdgeInsets    _priorScrollIndicatorInsets;
     BOOL            _keyboardVisible;
     CGRect          _keyboardRect;
 }
@@ -84,6 +85,7 @@
     }
     
     _priorInset = self.contentInset;
+    _priorScrollIndicatorInsets = self.scrollIndicatorInsets;
     
     // Shrink view's inset by the keyboard's height, and scroll to show the text field/view being edited
     [UIView beginAnimations:nil context:NULL];
@@ -108,7 +110,7 @@
     [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
     [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
     self.contentInset = _priorInset;
-    [self setScrollIndicatorInsets:self.contentInset];
+    self.scrollIndicatorInsets = _priorScrollIndicatorInsets;
     [UIView commitAnimations];
 }
 


### PR DESCRIPTION
...appeares. However, the prior value of scrollIndicatorInsets is not necessarily equal to that value and needs to be stored separately. This commit fixes this.
