### PR TITLE
Mark TPKeyboardAvoidingScrollView as implementing UITextFieldDelegate...

### DIFF
--- a/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.h
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.h
@@ -8,7 +8,7 @@
 #import <UIKit/UIKit.h>
 #import "UIScrollView+TPKeyboardAvoidingAdditions.h"
 
-@interface TPKeyboardAvoidingScrollView : UIScrollView
+@interface TPKeyboardAvoidingScrollView : UIScrollView<UITextFieldDelegate, UITextViewDelegate>
 - (void)contentSizeToFit;
 - (BOOL)focusNextTextField;
 - (void)scrollToActiveTextField;


### PR DESCRIPTION
also UITextViewDelegate

This allows for cases where other objects such as view controllers are the delegate of say a UITextField, but want to call the TPKeyboardAvoidingScrollView implementation to also get keyboard avoiding behaviour.
