### PR TITLE
Do not attempt to set contentSize for a keyboard-avoiding scroll view if...

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -55,8 +55,9 @@ static const int kStateKey;
     if ( [self isKindOfClass:[TPKeyboardAvoidingScrollView class]] ) {
         state.priorContentSize = self.contentSize;
         
-        if ( CGSizeEqualToSize(self.contentSize, CGSizeZero) ) {
-            // Set the content size, if it's not set
+        if ( self.constraints.count == 0 && CGSizeEqualToSize(self.contentSize, CGSizeZero) ) {
+            // Set the content size, if it's not set. Do not set content size explicitly if auto-layout
+            // is being used to manage subviews
             self.contentSize = [self TPKeyboardAvoiding_calculatedContentSizeFromSubviewFrames];
         }
     }


### PR DESCRIPTION
... autoLayout is used to manage the subviews.

if layout constraints are used to position subviews of a scrollview, then the contentSize will be derived from the layout constraints, and we should not be attempting to override it.
