### PR TITLE
Fixed issue #76.  In TPKeyboardAvoiding_calculatedContentSizeFromSubview...

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -203,13 +203,25 @@ static const int kStateKey;
 }
 
 -(CGSize)TPKeyboardAvoiding_calculatedContentSizeFromSubviewFrames {
+    
+    BOOL wasShowingVerticalScrollIndicator = self.showsVerticalScrollIndicator;
+    BOOL wasShowingHorizontalScrollIndicator = self.showsHorizontalScrollIndicator;
+    
+    self.showsVerticalScrollIndicator = NO;
+    self.showsHorizontalScrollIndicator = NO;
+    
     CGRect rect = CGRectZero;
     for ( UIView *view in self.subviews ) {
         rect = CGRectUnion(rect, view.frame);
     }
     rect.size.height += kCalculatedContentPadding;
+    
+    self.showsVerticalScrollIndicator = wasShowingVerticalScrollIndicator;
+    self.showsHorizontalScrollIndicator = wasShowingHorizontalScrollIndicator;
+    
     return rect.size;
 }
+
 
 - (UIEdgeInsets)TPKeyboardAvoiding_contentInsetForKeyboard {
     TPKeyboardAvoidingState *state = self.keyboardAvoidingState;


### PR DESCRIPTION
...Frames, the scroll indicators were included in the subview frame calculations.  Now we save the visibility of the scroll indicators, then turn them off while we calculate the new contentSize, then restore the scroll indicator visibility state.
