### PR TITLE
Prevent spurious newline insertion into UITextView on focus.

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -136,7 +136,7 @@ static const int kStateKey;
     
     if ( view ) {
         [firstResponder resignFirstResponder];
-        [view becomeFirstResponder];
+        [view performSelector:@selector(becomeFirstResponder) withObject:nil afterDelay:0.0];
         return YES;
     }
     


### PR DESCRIPTION
Hi, we encountered the same issue that's discussed here:

http://stackoverflow.com/questions/21077842/uitextview-adding-new-line-unintentionally

Apparently it's an iOS issue - have implemented the suggested fix on our fork and it has solved the issue for us.
