### PR TITLE
Added code to update scrollIndicatorInsets when updating contentInset.

### DIFF
--- a/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
@@ -68,7 +68,8 @@
 #pragma mark - Responders, events
 
 - (void) touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
-    [[self TPKeyboardAvoiding_findFirstResponderBeneathView:self] resignFirstResponder];
+    // RB: Not sure why this is here
+    // [[self TPKeyboardAvoiding_findFirstResponderBeneathView:self] resignFirstResponder];
     [super touchesEnded:touches withEvent:event];
 }
 

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
@@ -61,7 +61,8 @@
 #pragma mark - Responders, events
 
 - (void) touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
-    [[self TPKeyboardAvoiding_findFirstResponderBeneathView:self] resignFirstResponder];
+    // RB: Not sure why this is here.
+    // [[self TPKeyboardAvoiding_findFirstResponderBeneathView:self] resignFirstResponder];
     [super touchesEnded:touches withEvent:event];
 }
 

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
@@ -63,7 +63,8 @@
 #pragma mark - Responders, events
 
 - (void) touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
-    [[self TPKeyboardAvoiding_findFirstResponderBeneathView:self] resignFirstResponder];
+    // RB: Not sure why this is here
+    // [[self TPKeyboardAvoiding_findFirstResponderBeneathView:self] resignFirstResponder];
     [super touchesEnded:touches withEvent:event];
 }
 

--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -229,7 +229,7 @@ static const int kStateKey;
     TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
     UIEdgeInsets newInset = self.contentInset;
     CGRect keyboardRect = state.keyboardRect;
-    newInset.bottom = keyboardRect.size.height - (CGRectGetMaxY(keyboardRect) - CGRectGetMaxY(self.bounds));
+    newInset.bottom = keyboardRect.size.height - (CGRectGetMaxY(keyboardRect) - CGRectGetMaxY(self.frame));
     return newInset;
 }
 

--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -111,6 +111,7 @@ static const int kStateKey;
     TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
     if ( state.keyboardVisible ) {
         self.contentInset = [self TPKeyboardAvoiding_contentInsetForKeyboard];
+        self.scrollIndicatorInsets = self.contentInset;
     }
 }
 
@@ -119,6 +120,7 @@ static const int kStateKey;
     if ( state.keyboardVisible ) {
 		state.priorContentSize = self.contentSize;
         self.contentInset = [self TPKeyboardAvoiding_contentInsetForKeyboard];
+        self.scrollIndicatorInsets = self.contentInset;
     }
 }
 


### PR DESCRIPTION
Not sure if this works with scrollIndicator insets that were set by the user, but I was having issues where the contentInsets and scrollIndicatorInsets were not the same. In my I have a root UIView with a single UIScrollView as a child and a single UITextView as a child of the scroll view. the UITextView is setup with disabled scrolling. This fix works perfectly for my situation. 