### PR TITLE
Fixed the calculation of content Inset when using the method insertRowAtIndexPath: when keyboard is visible

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -227,7 +227,7 @@ static const int kStateKey;
     TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
     UIEdgeInsets newInset = self.contentInset;
     CGRect keyboardRect = state.keyboardRect;
-    newInset.bottom = keyboardRect.size.height - (CGRectGetMaxY(keyboardRect) - CGRectGetMaxY(self.bounds));
+    newInset.bottom = keyboardRect.size.height - MAX((CGRectGetMaxY(keyboardRect) - CGRectGetMaxY(self.bounds)), 0);
     return newInset;
 }
 


### PR DESCRIPTION
There's a bug when inserting a row on a tableview when the keyboard is visible. The method TPKeyboardAvoiding_contentInsetForKeyboard miscalculate the bottom inset returning a wrong value. The wrong value is due the (CGRectGetMaxY(keyboardRect) - CGRectGetMaxY(self.bounds) returns a negative value. I don't know if this can return negative values but it fixes the bug in my case.
