### PR TITLE
put each condition of if on its own statement line to help identify any expression evaluation crash

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -264,17 +264,22 @@ static const int kStateKey;
 }
 
 - (void)TPKeyboardAvoiding_initializeView:(UIView*)view {
-    if ( [view isKindOfClass:[UITextField class]] && ((UITextField*)view).returnKeyType == UIReturnKeyDefault && (![(id)view delegate] || [(id)view delegate] == self) ) {
-        [(id)view setDelegate:self];
-        UIView *otherView = nil;
-        CGFloat minY = CGFLOAT_MAX;
-        [self TPKeyboardAvoiding_findTextFieldAfterTextField:view beneathView:self minY:&minY foundView:&otherView];
-        
-        if ( otherView ) {
-            ((UITextField*)view).returnKeyType = UIReturnKeyNext;
-        } else {
-            ((UITextField*)view).returnKeyType = UIReturnKeyDone;
-        }
+    // put each condition of if on its own statement line to help identify any expression evaluation crash
+    if ( [view isKindOfClass:[UITextField class]] ) {
+      if (((UITextField*)view).returnKeyType == UIReturnKeyDefault) {
+        if (![(id)view delegate] || [(id)view delegate] == self)  {
+            [(id)view setDelegate:self];
+            UIView *otherView = nil;
+            CGFloat minY = CGFLOAT_MAX;
+            [self TPKeyboardAvoiding_findTextFieldAfterTextField:view beneathView:self minY:&minY foundView:&otherView];
+            
+            if ( otherView ) {
+                ((UITextField*)view).returnKeyType = UIReturnKeyNext;
+            } else {
+                ((UITextField*)view).returnKeyType = UIReturnKeyDone;
+            }
+         }
+      }
     }
 }
 


### PR DESCRIPTION
put each condition of if on its own statement line to help identify any expression evaluation crash
---
Reason for this change was we had an unreproducible SIGSEGV crash reported in TestFlightApp.com that pointed at the line:

-    if ( [view isKindOfClass:[UITextField class]] && ((UITextField*)view).returnKeyType == UIReturnKeyDefault && (![(id)view delegate] || [(id)view delegate] == self) ) {

The evaluation is so complex, it is difficult to determine which expression was causing the SIGSEGV.  Breaking up the evaluations into separate lines will allow TestFlightApp.com to more precisly identify which expression is causing the SIGSEGV.

Thanks!