### PR TITLE
Finer control over the scroll target, fixed content offset being stuck on iOS 7/Autolayout

### DIFF
--- a/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.h
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.h
@@ -14,16 +14,6 @@
 
 @optional
 /**
- *  Asks the keyboardAvoidingDelegate whether or not to adjust the scrollView offset for the specific current first responder.
- *
- *  @param scrollView     The TPKeyboardAvoidingScrollView that detected a change in the first responder.
- *  @param firstResponder The view that has just become first responder and is the target for the scroll.
- *
- *  @return YES if the scrollView should adjust its content offset. NO otherwise
- */
-- (BOOL)scrollView:(TPKeyboardAvoidingScrollView *)scrollView shouldAdjustOffsetForFirstResponder:(UIView *)firstResponder;
-
-/**
  *  Asks the delegate for a preferred content offset for a specific first responder. 
  *  Return the suggested offset if you agree with the default behaviour.
  *

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.h
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.h
@@ -8,7 +8,40 @@
 #import <UIKit/UIKit.h>
 #import "UIScrollView+TPKeyboardAvoidingAdditions.h"
 
+@class TPKeyboardAvoidingScrollView;
+
+@protocol TPKeyboardAvoidingScrollViewDelegate <NSObject>
+
+@optional
+/**
+ *  Asks the keyboardAvoidingDelegate whether or not to adjust the scrollView offset for the specific current first responder.
+ *
+ *  @param scrollView     The TPKeyboardAvoidingScrollView that detected a change in the first responder.
+ *  @param firstResponder The view that has just become first responder and is the target for the scroll.
+ *
+ *  @return YES if the scrollView should adjust its content offset. NO otherwise
+ */
+- (BOOL)scrollView:(TPKeyboardAvoidingScrollView *)scrollView shouldAdjustOffsetForFirstResponder:(UIView *)firstResponder;
+
+/**
+ *  Asks the delegate for a preferred content offset for a specific first responder. 
+ *  Return the suggested offset if you agree with the default behaviour.
+ *
+ *  @param scrollView      The TPKeyboardAvoidingScrollView that is about to change its contentOffset.
+ *  @param firstResponder  The view that has just become first responder and is the target for the scroll.
+ *  @param suggestedOffset The offset suggested by TPKeyboardAvoidingScrollView. Return this value if you want the default behaviour for this first responder.
+ *
+ *  @return The new contentOffset for the scrollView. Return suggestedOffset for the default behaviour.
+ */
+- (CGPoint)scrollView:(TPKeyboardAvoidingScrollView *)scrollView contentOffsetForFirstResponder:(UIView *)firstResponder suggestedOffset:(CGPoint)suggestedOffset;
+
+
+@end
+
 @interface TPKeyboardAvoidingScrollView : UIScrollView <UITextFieldDelegate, UITextViewDelegate>
+
+@property(nonatomic, assign) id<TPKeyboardAvoidingScrollViewDelegate> keyboardAvoidingDelegate;
+
 - (void)contentSizeToFit;
 - (BOOL)focusNextTextField;
 - (void)scrollToActiveTextField;

--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.h
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.h
@@ -18,5 +18,5 @@
 - (void)TPKeyboardAvoiding_updateFromContentSizeChange;
 - (void)TPKeyboardAvoiding_assignTextDelegateForViewsBeneathView:(UIView*)view;
 - (UIView*)TPKeyboardAvoiding_findFirstResponderBeneathView:(UIView*)view;
--(CGSize)TPKeyboardAvoiding_calculatedContentSizeFromSubviewFrames;
+- (CGSize)TPKeyboardAvoiding_calculatedContentSizeFromSubviewFrames;
 @end

--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -23,6 +23,7 @@ static const int kStateKey;
 @property (nonatomic, assign) BOOL         keyboardVisible;
 @property (nonatomic, assign) CGRect       keyboardRect;
 @property (nonatomic, assign) CGSize       priorContentSize;
+@property (nonatomic, assign) CGPoint      priorContentOffset;
 @end
 
 @implementation UIScrollView (TPKeyboardAvoidingAdditions)
@@ -71,6 +72,7 @@ static const int kStateKey;
     self.contentInset = [self TPKeyboardAvoiding_contentInsetForKeyboard];
     
     if ( firstResponder ) {
+        state.priorContentOffset = self.contentOffset;
         CGFloat viewableHeight = self.bounds.size.height - self.contentInset.top - self.contentInset.bottom;
         [self setContentOffset:CGPointMake(self.contentOffset.x,
                                            [self TPKeyboardAvoiding_idealOffsetForView:firstResponder
@@ -100,6 +102,8 @@ static const int kStateKey;
     
     if ( [self isKindOfClass:[TPKeyboardAvoidingScrollView class]] ) {
         self.contentSize = state.priorContentSize;
+        [self setContentOffset:state.priorContentOffset
+                      animated:NO];
     }
     
     self.contentInset = state.priorInset;

--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -71,17 +71,6 @@ static const int kStateKey;
     
     
     if ( firstResponder ) {
-        if([self isKindOfClass:[TPKeyboardAvoidingScrollView class]]) {
-            TPKeyboardAvoidingScrollView *selfWithCast = (TPKeyboardAvoidingScrollView *)self;
-            if([selfWithCast.keyboardAvoidingDelegate respondsToSelector:@selector(scrollView:shouldAdjustOffsetForFirstResponder:withPreferredContentOffset:)]) {
-                BOOL shouldAdjustContentOffset = [selfWithCast.keyboardAvoidingDelegate scrollView:selfWithCast
-                                                               shouldAdjustOffsetForFirstResponder:firstResponder];
-                if(!shouldAdjustContentOffset) {
-                    return;
-                }
-            }
-        }
-    
         self.contentInset = [self TPKeyboardAvoiding_contentInsetForKeyboard];
         state.priorContentOffset = self.contentOffset;
         


### PR DESCRIPTION
I included an optional protocol and delegate to give better control over the target content offset. (Only for TBKeyboardAvoidingScrollView, I have not yet used the TableView/CollectionView counterparts.)