### PR TITLE
Support for UITextField and UITextView delegates

### DIFF
--- a/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.h
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.h
@@ -11,4 +11,8 @@
 @interface TPKeyboardAvoidingCollectionView : UICollectionView <UITextFieldDelegate, UITextViewDelegate>
 - (BOOL)focusNextTextField;
 - (void)scrollToActiveTextField;
+
+@property (strong, nonatomic) id<UITextFieldDelegate> textFieldDelegate;
+@property (strong, nonatomic) id<UITextViewDelegate> textViewDelegate;
+
 @end

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
@@ -17,6 +17,8 @@
 - (void)setup {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
 }
 
 -(id)initWithFrame:(CGRect)frame {
@@ -100,8 +102,6 @@
 }
 
 -(void)textFieldDidBeginEditing:(UITextField *)textField {
-    [self scrollToActiveTextField];
-	
 	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldDidBeginEditing:)]) {
 		[self.textFieldDelegate textFieldDidBeginEditing:textField];
 	}
@@ -148,8 +148,6 @@
 #pragma mark - UITextView delegate methods
 
 -(void)textViewDidBeginEditing:(UITextView *)textView {
-    [self scrollToActiveTextField];
-	
 	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidBeginEditing:)]) {
 		[self.textViewDelegate textViewDidBeginEditing:textView];
 	}

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
@@ -17,8 +17,6 @@
 - (void)setup {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
 }
 
 -(id)initWithFrame:(CGRect)frame {
@@ -81,17 +79,130 @@
     [super touchesEnded:touches withEvent:event];
 }
 
--(BOOL)textFieldShouldReturn:(UITextField *)textField {
-    if ( ![self focusNextTextField] ) {
-        [textField resignFirstResponder];
-    }
-    return YES;
-}
-
 -(void)layoutSubviews {
     [super layoutSubviews];
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(TPKeyboardAvoiding_assignTextDelegateForViewsBeneathView:) object:self];
     [self performSelector:@selector(TPKeyboardAvoiding_assignTextDelegateForViewsBeneathView:) withObject:self afterDelay:0.1];
 }
+
+#pragma mark - UITextField delegate methods
+
+-(BOOL)textFieldShouldReturn:(UITextField *)textField {
+    if ( ![self focusNextTextField] ) {
+        [textField resignFirstResponder];
+    }
+	
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldReturn:)]) {
+		return [self.textFieldDelegate textFieldShouldReturn:textField];
+	}
+	
+    return YES;
+}
+
+-(void)textFieldDidBeginEditing:(UITextField *)textField {
+    [self scrollToActiveTextField];
+	
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldDidBeginEditing:)]) {
+		[self.textFieldDelegate textFieldDidBeginEditing:textField];
+	}
+}
+
+-(void)textFieldDidEndEditing:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldDidEndEditing:)]) {
+		[self.textFieldDelegate textFieldDidEndEditing:textField];
+	}
+}
+
+-(BOOL)textFieldShouldBeginEditing:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldBeginEditing:)]) {
+		return [self.textFieldDelegate textFieldShouldBeginEditing:textField];
+	}
+	
+	return YES;
+}
+
+-(BOOL)textFieldShouldEndEditing:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldEndEditing:)]) {
+		return [self.textFieldDelegate textFieldShouldEndEditing:textField];
+	}
+	
+	return YES;
+}
+
+-(BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
+		return [self.textFieldDelegate textField:textField shouldChangeCharactersInRange:range replacementString:string];
+	}
+	
+	return YES;
+}
+
+-(BOOL)textFieldShouldClear:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldClear:)]) {
+		return [self.textFieldDelegate textFieldShouldClear:textField];
+	}
+	
+	return YES;
+}
+
+#pragma mark - UITextView delegate methods
+
+-(void)textViewDidBeginEditing:(UITextView *)textView {
+    [self scrollToActiveTextField];
+	
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidBeginEditing:)]) {
+		[self.textViewDelegate textViewDidBeginEditing:textView];
+	}
+}
+
+- (BOOL)textViewShouldEndEditing:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewShouldEndEditing:)]) {
+		return [self.textViewDelegate textViewShouldEndEditing:textView];
+	}
+	
+	return YES;
+}
+
+- (void)textViewDidEndEditing:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidEndEditing:)]) {
+		return [self.textViewDelegate textViewDidEndEditing:textView];
+	}
+}
+
+- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textView:shouldChangeTextInRange:replacementText:)]) {
+		return [self.textViewDelegate textView:textView shouldChangeTextInRange:range replacementText:text];
+	}
+	
+	return YES;
+}
+
+- (void)textViewDidChange:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidChange:)]) {
+		return [self.textViewDelegate textViewDidChange:textView];
+	}
+}
+
+- (void)textViewDidChangeSelection:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidChangeSelection:)]) {
+		return [self.textViewDelegate textViewDidChangeSelection:textView];
+	}
+}
+
+- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textView:shouldInteractWithURL:inRange:)]) {
+		return [self.textViewDelegate textView:textView shouldInteractWithURL:URL inRange:characterRange];
+	}
+	return YES;
+}
+
+- (BOOL)textView:(UITextView *)textView shouldInteractWithTextAttachment:(NSTextAttachment *)textAttachment inRange:(NSRange)characterRange {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textView:shouldInteractWithTextAttachment:inRange:)]) {
+		return [self.textViewDelegate textView:textView shouldInteractWithTextAttachment:textAttachment inRange:characterRange];
+	}
+	
+	return YES;
+}
+
 
 @end

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
@@ -17,7 +17,7 @@
 - (void)setup {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
 }
 

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.h
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.h
@@ -12,4 +12,8 @@
 - (void)contentSizeToFit;
 - (BOOL)focusNextTextField;
 - (void)scrollToActiveTextField;
+
+@property (strong, nonatomic) id<UITextFieldDelegate> textFieldDelegate;
+@property (strong, nonatomic) id<UITextViewDelegate> textViewDelegate;
+
 @end

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
@@ -17,8 +17,6 @@
 - (void)setup {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
 }
 
 -(id)initWithFrame:(CGRect)frame {
@@ -74,17 +72,130 @@
     [super touchesEnded:touches withEvent:event];
 }
 
--(BOOL)textFieldShouldReturn:(UITextField *)textField {
-    if ( ![self focusNextTextField] ) {
-        [textField resignFirstResponder];
-    }
-    return YES;
-}
-
 -(void)layoutSubviews {
     [super layoutSubviews];
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(TPKeyboardAvoiding_assignTextDelegateForViewsBeneathView:) object:self];
     [self performSelector:@selector(TPKeyboardAvoiding_assignTextDelegateForViewsBeneathView:) withObject:self afterDelay:0.1];
 }
+
+#pragma mark - UITextField delegate methods
+
+-(BOOL)textFieldShouldReturn:(UITextField *)textField {
+    if ( ![self focusNextTextField] ) {
+        [textField resignFirstResponder];
+    }
+
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldReturn:)]) {
+		return [self.textFieldDelegate textFieldShouldReturn:textField];
+	}
+	
+    return YES;
+}
+
+-(void)textFieldDidBeginEditing:(UITextField *)textField {
+    [self scrollToActiveTextField];
+	
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldDidBeginEditing:)]) {
+		[self.textFieldDelegate textFieldDidBeginEditing:textField];
+	}
+}
+
+-(void)textFieldDidEndEditing:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldDidEndEditing:)]) {
+		[self.textFieldDelegate textFieldDidEndEditing:textField];
+	}
+}
+
+-(BOOL)textFieldShouldBeginEditing:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldBeginEditing:)]) {
+		return [self.textFieldDelegate textFieldShouldBeginEditing:textField];
+	}
+	
+	return YES;
+}
+
+-(BOOL)textFieldShouldEndEditing:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldEndEditing:)]) {
+		return [self.textFieldDelegate textFieldShouldEndEditing:textField];
+	}
+	
+	return YES;
+}
+
+-(BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
+		return [self.textFieldDelegate textField:textField shouldChangeCharactersInRange:range replacementString:string];
+	}
+	
+	return YES;
+}
+
+-(BOOL)textFieldShouldClear:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldClear:)]) {
+		return [self.textFieldDelegate textFieldShouldClear:textField];
+	}
+	
+	return YES;
+}
+
+#pragma mark - UITextView delegate methods
+
+-(void)textViewDidBeginEditing:(UITextView *)textView {
+    [self scrollToActiveTextField];
+	
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidBeginEditing:)]) {
+		[self.textViewDelegate textViewDidBeginEditing:textView];
+	}
+}
+
+- (BOOL)textViewShouldEndEditing:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewShouldEndEditing:)]) {
+		return [self.textViewDelegate textViewShouldEndEditing:textView];
+	}
+	
+	return YES;
+}
+
+- (void)textViewDidEndEditing:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidEndEditing:)]) {
+		return [self.textViewDelegate textViewDidEndEditing:textView];
+	}
+}
+
+- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textView:shouldChangeTextInRange:replacementText:)]) {
+		return [self.textViewDelegate textView:textView shouldChangeTextInRange:range replacementText:text];
+	}
+	
+	return YES;
+}
+
+- (void)textViewDidChange:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidChange:)]) {
+		return [self.textViewDelegate textViewDidChange:textView];
+	}
+}
+
+- (void)textViewDidChangeSelection:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidChangeSelection:)]) {
+		return [self.textViewDelegate textViewDidChangeSelection:textView];
+	}
+}
+
+- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textView:shouldInteractWithURL:inRange:)]) {
+		return [self.textViewDelegate textView:textView shouldInteractWithURL:URL inRange:characterRange];
+	}
+	return YES;
+}
+
+- (BOOL)textView:(UITextView *)textView shouldInteractWithTextAttachment:(NSTextAttachment *)textAttachment inRange:(NSRange)characterRange {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textView:shouldInteractWithTextAttachment:inRange:)]) {
+		return [self.textViewDelegate textView:textView shouldInteractWithTextAttachment:textAttachment inRange:characterRange];
+	}
+	
+	return YES;	
+}
+
 
 @end

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
@@ -17,6 +17,8 @@
 - (void)setup {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];	
 }
 
 -(id)initWithFrame:(CGRect)frame {
@@ -93,8 +95,6 @@
 }
 
 -(void)textFieldDidBeginEditing:(UITextField *)textField {
-    [self scrollToActiveTextField];
-	
 	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldDidBeginEditing:)]) {
 		[self.textFieldDelegate textFieldDidBeginEditing:textField];
 	}
@@ -141,8 +141,6 @@
 #pragma mark - UITextView delegate methods
 
 -(void)textViewDidBeginEditing:(UITextView *)textView {
-    [self scrollToActiveTextField];
-	
 	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidBeginEditing:)]) {
 		[self.textViewDelegate textViewDidBeginEditing:textView];
 	}

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.h
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.h
@@ -11,4 +11,8 @@
 @interface TPKeyboardAvoidingTableView : UITableView <UITextFieldDelegate, UITextViewDelegate>
 - (BOOL)focusNextTextField;
 - (void)scrollToActiveTextField;
+
+@property (strong, nonatomic) id<UITextFieldDelegate> textFieldDelegate;
+@property (strong, nonatomic) id<UITextViewDelegate> textViewDelegate;
+
 @end

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
@@ -17,6 +17,8 @@
 - (void)setup {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
 }
 
 -(id)initWithFrame:(CGRect)frame {
@@ -95,8 +97,6 @@
 }
 
 -(void)textFieldDidBeginEditing:(UITextField *)textField {
-    [self scrollToActiveTextField];
-	
 	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldDidBeginEditing:)]) {
 		[self.textFieldDelegate textFieldDidBeginEditing:textField];
 	}
@@ -143,8 +143,6 @@
 #pragma mark - UITextView delegate methods
 
 -(void)textViewDidBeginEditing:(UITextView *)textView {
-    [self scrollToActiveTextField];
-	
 	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidBeginEditing:)]) {
 		[self.textViewDelegate textViewDidBeginEditing:textView];
 	}

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
@@ -17,8 +17,6 @@
 - (void)setup {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
 }
 
 -(id)initWithFrame:(CGRect)frame {
@@ -76,17 +74,129 @@
     [super touchesEnded:touches withEvent:event];
 }
 
--(BOOL)textFieldShouldReturn:(UITextField *)textField {
-    if ( ![self focusNextTextField] ) {
-        [textField resignFirstResponder];
-    }
-    return YES;
-}
-
 -(void)layoutSubviews {
     [super layoutSubviews];
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(TPKeyboardAvoiding_assignTextDelegateForViewsBeneathView:) object:self];
     [self performSelector:@selector(TPKeyboardAvoiding_assignTextDelegateForViewsBeneathView:) withObject:self afterDelay:0.1];
+}
+
+#pragma mark - UITextField delegate methods
+
+-(BOOL)textFieldShouldReturn:(UITextField *)textField {
+    if ( ![self focusNextTextField] ) {
+        [textField resignFirstResponder];
+    }
+	
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldReturn:)]) {
+		return [self.textFieldDelegate textFieldShouldReturn:textField];
+	}
+	
+    return YES;
+}
+
+-(void)textFieldDidBeginEditing:(UITextField *)textField {
+    [self scrollToActiveTextField];
+	
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldDidBeginEditing:)]) {
+		[self.textFieldDelegate textFieldDidBeginEditing:textField];
+	}
+}
+
+-(void)textFieldDidEndEditing:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldDidEndEditing:)]) {
+		[self.textFieldDelegate textFieldDidEndEditing:textField];
+	}
+}
+
+-(BOOL)textFieldShouldBeginEditing:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldBeginEditing:)]) {
+		return [self.textFieldDelegate textFieldShouldBeginEditing:textField];
+	}
+	
+	return YES;
+}
+
+-(BOOL)textFieldShouldEndEditing:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldEndEditing:)]) {
+		return [self.textFieldDelegate textFieldShouldEndEditing:textField];
+	}
+	
+	return YES;
+}
+
+-(BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
+		return [self.textFieldDelegate textField:textField shouldChangeCharactersInRange:range replacementString:string];
+	}
+	
+	return YES;
+}
+
+-(BOOL)textFieldShouldClear:(UITextField *)textField {
+	if(self.textFieldDelegate && [self.textFieldDelegate respondsToSelector:@selector(textFieldShouldClear:)]) {
+		return [self.textFieldDelegate textFieldShouldClear:textField];
+	}
+	
+	return YES;
+}
+
+#pragma mark - UITextView delegate methods
+
+-(void)textViewDidBeginEditing:(UITextView *)textView {
+    [self scrollToActiveTextField];
+	
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidBeginEditing:)]) {
+		[self.textViewDelegate textViewDidBeginEditing:textView];
+	}
+}
+
+- (BOOL)textViewShouldEndEditing:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewShouldEndEditing:)]) {
+		return [self.textViewDelegate textViewShouldEndEditing:textView];
+	}
+	
+	return YES;
+}
+
+- (void)textViewDidEndEditing:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidEndEditing:)]) {
+		return [self.textViewDelegate textViewDidEndEditing:textView];
+	}
+}
+
+- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textView:shouldChangeTextInRange:replacementText:)]) {
+		return [self.textViewDelegate textView:textView shouldChangeTextInRange:range replacementText:text];
+	}
+	
+	return YES;
+}
+
+- (void)textViewDidChange:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidChange:)]) {
+		return [self.textViewDelegate textViewDidChange:textView];
+	}
+}
+
+- (void)textViewDidChangeSelection:(UITextView *)textView {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textViewDidChangeSelection:)]) {
+		return [self.textViewDelegate textViewDidChangeSelection:textView];
+	}
+}
+
+- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textView:shouldInteractWithURL:inRange:)]) {
+		return [self.textViewDelegate textView:textView shouldInteractWithURL:URL inRange:characterRange];
+	}
+	return YES;
+}
+
+- (BOOL)textView:(UITextView *)textView shouldInteractWithTextAttachment:(NSTextAttachment *)textAttachment inRange:(NSRange)characterRange {
+	if(self.textViewDelegate && [self.textViewDelegate respondsToSelector:@selector(textView:shouldInteractWithTextAttachment:inRange:)]) {
+		return [self.textViewDelegate textView:textView shouldInteractWithTextAttachment:textAttachment inRange:characterRange];
+	}
+	
+	return YES;
 }
 
 @end

--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -278,6 +278,10 @@ static const int kStateKey;
             ((UITextField*)view).returnKeyType = UIReturnKeyDone;
         }
     }
+	
+	if ( [view isKindOfClass:[UITextView class]]) {
+		[(UITextView*)view setDelegate:(id<UITextViewDelegate>)self];
+	}
 }
 
 @end


### PR DESCRIPTION
Added support for UITextViewDelegate and UITextFieldDelegate chaining.
The drop-in replacement now declares two new properties
textFieldDelegate and textViewDelegate can be used to set second level
delegates.