### PR TITLE
compile without a pch file on xcode 6.0

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.h
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.h
@@ -6,7 +6,7 @@
 //  Copyright 2013 A Tasty Pixel. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface UIScrollView (TPKeyboardAvoidingAdditions)
 - (BOOL)TPKeyboardAvoiding_focusNextTextField;


### PR DESCRIPTION
I was receiving a warning that UIScrollView was not defined. Most people are probably using a PCH with UIKit in it which would hide this issue.
