### PR TITLE
Chinese-Simplified on iOS7

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -42,9 +42,9 @@ static const int kStateKey;
 - (void)TPKeyboardAvoiding_keyboardWillShow:(NSNotification*)notification {
     TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
     
-    if ( state.keyboardVisible ) {
-        return;
-    }
+//    if ( state.keyboardVisible ) {
+//        return;
+//    }
     
     UIView *firstResponder = [self TPKeyboardAvoiding_findFirstResponderBeneathView:self];
     
@@ -102,8 +102,10 @@ static const int kStateKey;
         self.contentSize = state.priorContentSize;
     }
     
-    self.contentInset = state.priorInset;
-    self.scrollIndicatorInsets = state.priorScrollIndicatorInsets;
+//    self.contentInset = state.priorInset;
+//    self.scrollIndicatorInsets = state.priorScrollIndicatorInsets;
+    self.contentInset = UIEdgeInsetsZero;
+    self.scrollIndicatorInsets = UIEdgeInsetsZero;
     [UIView commitAnimations];
 }
 


### PR DESCRIPTION
When I use Chinese-Simplified keyboard on iOS7, the table will no
change frame, keyboard blocked UITextField.