### PR TITLE
Scrollview stuttering problem on content inset/offset change fixed

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -79,6 +79,7 @@ static const int kStateKey;
     }
     
     self.scrollIndicatorInsets = self.contentInset;
+    [self layoutIfNeeded];
     
     [UIView commitAnimations];
 }
@@ -104,6 +105,7 @@ static const int kStateKey;
     
     self.contentInset = state.priorInset;
     self.scrollIndicatorInsets = state.priorScrollIndicatorInsets;
+    [self layoutIfNeeded];
     [UIView commitAnimations];
 }
 
@@ -156,6 +158,7 @@ static const int kStateKey;
     // scroll to the desired content offset. So we wrap in our own animation block.
     [UIView animateWithDuration:0.25 animations:^{
         [self setContentOffset:idealOffset animated:NO];
+        [self layoutIfNeeded];
     }];
 }
 

--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -154,12 +154,11 @@ static const int kStateKey;
     CGPoint idealOffset = CGPointMake(0, [self TPKeyboardAvoiding_idealOffsetForView:[self TPKeyboardAvoiding_findFirstResponderBeneathView:self]
                                                                withViewingAreaHeight:visibleSpace]);
 
-    // Ordinarily we'd use -setContentOffset:animated:YES here, but it does not appear to
-    // scroll to the desired content offset. So we wrap in our own animation block.
-    [UIView animateWithDuration:0.25 animations:^{
-        [self setContentOffset:idealOffset animated:NO];
-        [self layoutIfNeeded];
-    }];
+    // Ordinarily we'd use -setContentOffset:animated:YES here, but it interferes with UIScrollView
+    // behavior which automatically ensures that the first responder is within its bounds
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self setContentOffset:idealOffset animated:YES];
+    });
 }
 
 #pragma mark - Helpers


### PR DESCRIPTION
Hi, first of all thanks for the great work! :)

However I had a problem, possibly with auto-layouted scrollviews - they jumps up during KB show/hide animations.
In the project's sample I not found this issue, so I think it can be associated with the autolayouted views.
But if you wanna see some achievement from this commit quickly, the sample's collection view top part also healed (currently you can see a disappearing gray box during KB animation).

Cheers