### PR TITLE
Fix a bug that view won't move if using a 3rd party input method.

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -49,7 +49,7 @@ static const int kStateKey;
     UIView *firstResponder = [self TPKeyboardAvoiding_findFirstResponderBeneathView:self];
     
     state.keyboardRect = [self convertRect:[[[notification userInfo] objectForKey:_UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
-    state.keyboardVisible = YES;
+    state.keyboardVisible = !CGRectIsEmpty(state.keyboardRect);
     state.priorInset = self.contentInset;
     state.priorScrollIndicatorInsets = self.scrollIndicatorInsets;
     


### PR DESCRIPTION
I should thank you first that I use your codes in my projects for a long time.
And I find a bug about using the 3rd party input method in iOS 8, the scroll view won't move.
