### PR TITLE
add support for third-party keyboard(fix #148)

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -58,15 +58,18 @@ static const int kStateKey;
     }
     
     UIView *firstResponder = [self TPKeyboardAvoiding_findFirstResponderBeneathView:self];
-    
+
     state.keyboardRect = keyboardRect;
     state.keyboardVisible = YES;
-    state.priorInset = self.contentInset;
-    state.priorScrollIndicatorInsets = self.scrollIndicatorInsets;
     
-    state.priorPagingEnabled = self.pagingEnabled;
+    if ( !state.keyboardVisible ) {
+        state.priorInset = self.contentInset;
+        state.priorScrollIndicatorInsets = self.scrollIndicatorInsets;
+        state.priorPagingEnabled = self.pagingEnabled;
+    }
+
     self.pagingEnabled = NO;
-    
+        
     if ( [self isKindOfClass:[TPKeyboardAvoidingScrollView class]] ) {
         state.priorContentSize = self.contentSize;
         


### PR DESCRIPTION
when using a third-party keyboard , the " TPKeyboardAvoiding_keyboardWillShow:(NSNotification*)notification " will be called more then once with different keyboard size. So TPKeyboardAvoiding can't work well.

This patch make TPKeyboardAvoiding work well with third-party keyboard.

please merge it. Thank you.