### PR TITLE
Prevent triggering contentSize when it's already the same, fix issue #155

### DIFF
--- a/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
@@ -50,6 +50,11 @@
 }
 
 -(void)setContentSize:(CGSize)contentSize {
+	if (CGSizeEqualToSize(contentSize, self.contentSize)) {
+		// Prevent triggering contentSize when it's already the same
+		// this cause table view to scroll to top on contentInset changes
+		return;
+	}
     [super setContentSize:contentSize];
     [self TPKeyboardAvoiding_updateContentInset];
 }


### PR DESCRIPTION
Fixes this issue:
https://github.com/michaeltyson/TPKeyboardAvoiding/issues/155