### PR TITLE
Add a new TPKeyboardAvoiding_setAdditionalContentOffset to UIScrollView.

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.h
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.h
@@ -19,4 +19,9 @@
 - (void)TPKeyboardAvoiding_assignTextDelegateForViewsBeneathView:(UIView*)view;
 - (UIView*)TPKeyboardAvoiding_findFirstResponderBeneathView:(UIView*)view;
 -(CGSize)TPKeyboardAvoiding_calculatedContentSizeFromSubviewFrames;
+
+/// When set, apply an additional content offset to the offset
+/// TPKeyboardAvoiding would apply normally.
+- (void)TPKeyboardAvoiding_setAdditionalContentOffset:(CGPoint)contentOffset;
+
 @end


### PR DESCRIPTION
I needed to apply an offset to the applied content offset of TPKeyboardAvoiding and thus created this patch.
The additional offset is added to the originally computed offset of TPKeyboardAvoiding. The additional offset is to be set on each UIScrollView on which it is desired.