### PR TITLE
Fixing iOS 9 text field jump when focusing on next field

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -62,6 +62,8 @@ static const int kStateKey;
         state.priorInset = self.contentInset;
         state.priorScrollIndicatorInsets = self.scrollIndicatorInsets;
         state.priorPagingEnabled = self.pagingEnabled;
+    } else {
+        return;
     }
     
     state.keyboardVisible = YES;


### PR DESCRIPTION
This seems to fix issue #186 caused by animations in keyboardWillShow method while switching between text fields. Is there any reason not to return here if keyboard is already visible?