### PR TITLE
[Bug] Fix a bug that when check whether a view is hidden or user interaction not enabled.

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -240,8 +240,20 @@ static const int kStateKey;
           + (-frame.origin.x);         // Prefer elements closest to left
 }
 
+- (BOOL)TPKeyboardAvoiding_viewHiddenOrUserInteractionNotEnabled:(UIView *)view
+{
+    UIView *checkView = view;
+    while (checkView) {
+        if (checkView.hidden || !checkView.userInteractionEnabled) {
+            return YES;
+        }
+        checkView = checkView.superview;
+    }
+    return NO;
+}
+
 - (BOOL)TPKeyboardAvoiding_viewIsValidKeyViewCandidate:(UIView *)view {
-    if ( view.hidden || !view.userInteractionEnabled ) return NO;
+    if ( [self TPKeyboardAvoiding_viewHiddenOrUserInteractionNotEnabled:view] ) return NO;
     
     if ( [view isKindOfClass:[UITextField class]] && ((UITextField*)view).enabled ) {
         return YES;


### PR DESCRIPTION
When check whether a view is hidden or user interaction not enabled, we should check its super view recursively.
