### PR TITLE
Change the height calculations on the UIScrollView category to take only the maximum visible height

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -42,6 +42,10 @@ static const int kStateKey;
 }
 
 - (void)TPKeyboardAvoiding_keyboardWillShow:(NSNotification*)notification {
+    // Check that the iOS is at least 7. Using this pod on 7 leads to some unexpected jumpy behavior.
+    if (![[NSProcessInfo processInfo] respondsToSelector:@selector(isOperatingSystemAtLeastVersion:)]){
+        return;
+    }
     CGRect keyboardRect = [self convertRect:[[[notification userInfo] objectForKey:_UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
     if (CGRectIsEmpty(keyboardRect)) {
         return;
@@ -175,7 +179,7 @@ static const int kStateKey;
 -(void)TPKeyboardAvoiding_scrollToActiveTextField {
     TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
     
-    if ( !state.keyboardVisible ) return;
+    if ( !state.keyboardVisible || ![[NSProcessInfo processInfo] respondsToSelector:@selector(isOperatingSystemAtLeastVersion:)] ) return;
     
     CGFloat visibleSpace = self.bounds.size.height - self.contentInset.top - self.contentInset.bottom;
     


### PR DESCRIPTION
I was having trouble with a UIScroll view's frame when the keyboard dismissed. Since the category set the frame from the union of all the frames in the view, the frame of my scroll view was getting set slightly larger than the visible frame of the screen, which allowed the user to scroll around after the keyboard dismissed. This fixes that issue for me. 