### PR TITLE
fix issue when the last input field's securityEntry is set to YES

### DIFF
--- a/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
@@ -20,8 +20,6 @@
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillShow:) name:UIKeyboardWillChangeFrameNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
 }
 
 -(id)initWithFrame:(CGRect)frame {

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
@@ -18,8 +18,6 @@
 - (void)setup {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillShow:) name:UIKeyboardWillChangeFrameNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
 }
 
 -(id)initWithFrame:(CGRect)frame {

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
@@ -20,8 +20,6 @@
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillShow:) name:UIKeyboardWillChangeFrameNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
 }
 
 -(id)initWithFrame:(CGRect)frame {

--- a/TPKeyboardAvoidingSample/TPKAScrollViewController.m
+++ b/TPKeyboardAvoidingSample/TPKAScrollViewController.m
@@ -26,6 +26,9 @@ static const int kGroupCount = 5;
         UITextField * textField = [[UITextField alloc] initWithFrame:CGRectZero];
         textField.translatesAutoresizingMaskIntoConstraints = NO;
         textField.placeholder = [NSString stringWithFormat:@"Field %d", i];
+        if (i == 39) {
+            textField.secureTextEntry = YES;
+        }
         textField.borderStyle = UITextBorderStyleRoundedRect;
         [self.scrollView addSubview:textField];
         


### PR DESCRIPTION
adding TPKeyboardAvoidScrollView, TPKeyboardAvoidTableView and TPKeyboardAvoidCollectionView as observers for UITextFieldTextDidBeginEditingNotification/UITextViewTextDidBeginEditingNotification, causes scrollToActiveTextField method to be fired before keyboardWillShow: and this results in calculating a wrong offset in TPKeyboardAvoiding_idealOffsetForView: withViewingAreaHeight:
Also, I cannot think of a case when you have to listen to those notifications, as the offsets will eventually be calculated inside keyboardWillShow: 
I have edited the Sample project so that the last textfield has securityEntry set to YES.