### PR TITLE
Fix a bug with wrong content insets after fast clicking

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -84,6 +84,7 @@ static const int kStateKey;
     [UIView beginAnimations:nil context:NULL];
     [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
     [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
+    [UIView setAnimationBeginsFromCurrentState:YES];
     
     self.contentInset = [self TPKeyboardAvoiding_contentInsetForKeyboard];
     
@@ -100,9 +101,11 @@ static const int kStateKey;
 }
 
 - (void)TPKeyboardAvoiding_keyboardWillHide:(NSNotification*)notification {
-    CGRect keyboardRect = [self convertRect:[[[notification userInfo] objectForKey:_UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
-    if (CGRectIsEmpty(keyboardRect)) {
-        return;
+    if (![notification.name isEqualToString:UIKeyboardWillHideNotification]) {
+        CGRect keyboardRect = [self convertRect:[[[notification userInfo] objectForKey:_UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
+        if (CGRectIsEmpty(keyboardRect)) {
+            return;
+        }
     }
     
     TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
@@ -122,6 +125,7 @@ static const int kStateKey;
     [UIView beginAnimations:nil context:NULL];
     [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
     [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
+    [UIView setAnimationBeginsFromCurrentState:YES];
     
     if ( [self isKindOfClass:[TPKeyboardAvoidingScrollView class]] ) {
         self.contentSize = state.priorContentSize;


### PR DESCRIPTION
When click on a text field and then fast click off text field (before keyboard appears), content insets not reset to normal

![contentinsetsnotresetbug](https://cloud.githubusercontent.com/assets/574173/10783246/6c78d88a-7d67-11e5-8f16-906da2286ab9.gif)
