### PR TITLE
added TPKeyboardAvoidingAdditionsOptions protocol

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.h
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.h
@@ -8,6 +8,10 @@
 
 #import <UIKit/UIKit.h>
 
+@protocol TPKeyboardAvoidingAdditionsOptions <NSObject>
+- (BOOL)TPKeyboardAvoiding_idealOffsetForViewAlwaysTop;
+@end
+
 @interface UIScrollView (TPKeyboardAvoidingAdditions)
 - (BOOL)TPKeyboardAvoiding_focusNextTextField;
 - (void)TPKeyboardAvoiding_scrollToActiveTextField;

--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -334,6 +334,10 @@ static const int kStateKey;
 
     CGRect subviewRect = [view convertRect:view.bounds toView:self];
     
+    // Allow views to specify their need to float to the top instead of towards the middle.
+    if([view respondsToSelector:@selector(TPKeyboardAvoiding_idealOffsetForViewAlwaysTop)] && [((id<TPKeyboardAvoidingAdditionsOptions>)view) TPKeyboardAvoiding_idealOffsetForViewAlwaysTop])
+        return subviewRect.origin.y;
+
     // Attempt to center the subview in the visible space, but if that means there will be less than kMinimumScrollOffsetPadding
     // pixels above the view, then substitute kMinimumScrollOffsetPadding
     CGFloat padding = (viewAreaHeight - subviewRect.size.height) / 2;


### PR DESCRIPTION
to allow for views to override specific pieces of functionality as needed

added TPKeyboardAvoiding_idealOffsetForViewAlwaysTop to allow views to be able to float to the top instead of middle
    use case: have an 'autocomplete' style dropdown for one of my textfields. Need as much room as possible between the field and the keyboard, this will (safely) alter the math in calculating the scroll position so the textfield can specify that it needs to be on the top instead of the middle
