### PR TITLE
Fix for a scrolling bug when the first responder is a tall text input

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -43,63 +43,71 @@ static const int kStateKey;
 }
 
 - (void)TPKeyboardAvoiding_keyboardWillShow:(NSNotification*)notification {
-    CGRect keyboardRect = [self convertRect:[[[notification userInfo] objectForKey:_UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
-    if (CGRectIsEmpty(keyboardRect)) {
-        return;
-    }
-    
-    TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
-    
-    if ( state.ignoringNotifications ) {
-        return;
-    }
-    
-    state.keyboardRect = keyboardRect;
-    
-    if ( !state.keyboardVisible ) {
-        state.priorInset = self.contentInset;
-        state.priorScrollIndicatorInsets = self.scrollIndicatorInsets;
-        state.priorPagingEnabled = self.pagingEnabled;
-    }
-    
-    state.keyboardVisible = YES;
-    self.pagingEnabled = NO;
-        
-    if ( [self isKindOfClass:[TPKeyboardAvoidingScrollView class]] ) {
-        state.priorContentSize = self.contentSize;
-        
-        if ( CGSizeEqualToSize(self.contentSize, CGSizeZero) ) {
-            // Set the content size, if it's not set. Do not set content size explicitly if auto-layout
-            // is being used to manage subviews
-            self.contentSize = [self TPKeyboardAvoiding_calculatedContentSizeFromSubviewFrames];
+
+    // Delay until a future run loop such that the cursor position is available in a text view
+    // In other words, it's not available (specifically, the prior cursor position is returned) when the first keyboard position change notification fires
+    // NOTE: Unfortunately, using dispatch_async(main_queue) did not result in a sufficient-enough delay
+    // for the text view's current cursor position to be available
+    dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC));
+    dispatch_after(delay, dispatch_get_main_queue(), ^{
+        CGRect keyboardRect = [self convertRect:[[[notification userInfo] objectForKey:_UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
+        if (CGRectIsEmpty(keyboardRect)) {
+            return;
         }
-    }
-    
-    // Shrink view's inset by the keyboard's height, and scroll to show the text field/view being edited
-    [UIView beginAnimations:nil context:NULL];
-    
-    [UIView setAnimationDelegate:self];
-    [UIView setAnimationWillStartSelector:@selector(keyboardViewAppear:context:)];
-    [UIView setAnimationDidStopSelector:@selector(keyboardViewDisappear:finished:context:)];
-    
-    [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
-    [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
-    
-    self.contentInset = [self TPKeyboardAvoiding_contentInsetForKeyboard];
-    
-    UIView *firstResponder = [self TPKeyboardAvoiding_findFirstResponderBeneathView:self];
-    if ( firstResponder ) {
-        CGFloat viewableHeight = self.bounds.size.height - self.contentInset.top - self.contentInset.bottom;
-        [self setContentOffset:CGPointMake(self.contentOffset.x,
-                                           [self TPKeyboardAvoiding_idealOffsetForView:firstResponder
-                                                                 withViewingAreaHeight:viewableHeight])
-                      animated:NO];
-    }
-    
-    self.scrollIndicatorInsets = self.contentInset;
-    [self layoutIfNeeded];
-    
-    [UIView commitAnimations];
+        
+        TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
+        
+        if ( state.ignoringNotifications ) {
+            return;
+        }
+        
+        state.keyboardRect = keyboardRect;
+        
+        if ( !state.keyboardVisible ) {
+            state.priorInset = self.contentInset;
+            state.priorScrollIndicatorInsets = self.scrollIndicatorInsets;
+            state.priorPagingEnabled = self.pagingEnabled;
+        }
+        
+        state.keyboardVisible = YES;
+        self.pagingEnabled = NO;
+            
+        if ( [self isKindOfClass:[TPKeyboardAvoidingScrollView class]] ) {
+            state.priorContentSize = self.contentSize;
+            
+            if ( CGSizeEqualToSize(self.contentSize, CGSizeZero) ) {
+                // Set the content size, if it's not set. Do not set content size explicitly if auto-layout
+                // is being used to manage subviews
+                self.contentSize = [self TPKeyboardAvoiding_calculatedContentSizeFromSubviewFrames];
+            }
+        }
+        
+        // Shrink view's inset by the keyboard's height, and scroll to show the text field/view being edited
+        [UIView beginAnimations:nil context:NULL];
+        
+        [UIView setAnimationDelegate:self];
+        [UIView setAnimationWillStartSelector:@selector(keyboardViewAppear:context:)];
+        [UIView setAnimationDidStopSelector:@selector(keyboardViewDisappear:finished:context:)];
+        
+        [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
+        [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
+        
+        self.contentInset = [self TPKeyboardAvoiding_contentInsetForKeyboard];
+        
+        UIView *firstResponder = [self TPKeyboardAvoiding_findFirstResponderBeneathView:self];
+        if ( firstResponder ) {
+            CGFloat viewableHeight = self.bounds.size.height - self.contentInset.top - self.contentInset.bottom;
+            [self setContentOffset:CGPointMake(self.contentOffset.x,
+                                               [self TPKeyboardAvoiding_idealOffsetForView:firstResponder
+                                                                     withViewingAreaHeight:viewableHeight])
+                          animated:NO];
+        }
+        
+        self.scrollIndicatorInsets = self.contentInset;
+        [self layoutIfNeeded];
+        
+        [UIView commitAnimations];
+    });
 }
 
 - (void)keyboardViewAppear:(NSString *)animationID context:(void *)context {
@@ -330,21 +338,55 @@ static const int kStateKey;
 
 -(CGFloat)TPKeyboardAvoiding_idealOffsetForView:(UIView *)view withViewingAreaHeight:(CGFloat)viewAreaHeight {
     CGSize contentSize = self.contentSize;
-    CGFloat offset = 0.0;
+    __block CGFloat offset = 0.0;
 
     CGRect subviewRect = [view convertRect:view.bounds toView:self];
-    
-    // Attempt to center the subview in the visible space, but if that means there will be less than kMinimumScrollOffsetPadding
-    // pixels above the view, then substitute kMinimumScrollOffsetPadding
-    CGFloat padding = (viewAreaHeight - subviewRect.size.height) / 2;
-    if ( padding < kMinimumScrollOffsetPadding ) {
-        padding = kMinimumScrollOffsetPadding;
-    }
 
-    // Ideal offset places the subview rectangle origin "padding" points from the top of the scrollview.
-    // If there is a top contentInset, also compensate for this so that subviewRect will not be placed under
-    // things like navigation bars.
-    offset = subviewRect.origin.y - padding - self.contentInset.top;
+    __block CGFloat padding = 0.0;
+
+    void(^centerViewInViewableArea)()  = ^ {
+        // Attempt to center the subview in the visible space
+        padding = (viewAreaHeight - subviewRect.size.height) / 2;
+
+        // But if that means there will be less than kMinimumScrollOffsetPadding
+        // pixels above the view, then substitute kMinimumScrollOffsetPadding
+        if (padding < kMinimumScrollOffsetPadding ) {
+            padding = kMinimumScrollOffsetPadding;
+        }
+
+        // Ideal offset places the subview rectangle origin "padding" points from the top of the scrollview.
+        // If there is a top contentInset, also compensate for this so that subviewRect will not be placed under
+        // things like navigation bars.
+        offset = subviewRect.origin.y - padding - self.contentInset.top;
+    };
+
+    // If possible, center the caret in the visible space. Otherwise, center the entire view in the visible space.
+    if ([view conformsToProtocol:@protocol(UITextInput)]) {
+        UIView <UITextInput> *textInput = (UIView <UITextInput>*)view;
+        UITextPosition *caretPosition = [textInput selectedTextRange].start;
+        if (caretPosition) {
+            CGRect caretRect = [self convertRect:[textInput caretRectForPosition:caretPosition] fromView:textInput];
+
+            // Attempt to center the cursor in the visible space
+            // pixels above the view, then substitute kMinimumScrollOffsetPadding
+            padding = (viewAreaHeight - caretRect.size.height) / 2;
+
+            // But if that means there will be less than kMinimumScrollOffsetPadding
+            // pixels above the view, then substitute kMinimumScrollOffsetPadding
+            if (padding < kMinimumScrollOffsetPadding ) {
+                padding = kMinimumScrollOffsetPadding;
+            }
+
+            // Ideal offset places the subview rectangle origin "padding" points from the top of the scrollview.
+            // If there is a top contentInset, also compensate for this so that subviewRect will not be placed under
+            // things like navigation bars.
+            offset = caretRect.origin.y - padding - self.contentInset.top;
+        } else {
+            centerViewInViewableArea();
+        }
+    } else {
+        centerViewInViewableArea();
+    }
     
     // Constrain the new contentOffset so we can't scroll past the bottom. Note that we don't take the bottom
     // inset into account, as this is manipulated to make space for the keyboard.

--- a/TPKeyboardAvoidingSample/Base.lproj/Main.storyboard
+++ b/TPKeyboardAvoidingSample/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -19,8 +20,10 @@
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E74-nH-O4B" customClass="TPKeyboardAvoidingScrollView">
                                 <rect key="frame" x="0.0" y="20" width="600" height="531"/>
+                                <animations/>
                             </scrollView>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="4ug-Mw-9AY" firstAttribute="top" secondItem="E74-nH-O4B" secondAttribute="bottom" id="HmI-ZY-YxY"/>
@@ -53,6 +56,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="ahS-NI-zlB" customClass="TPKeyboardAvoidingTableView">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="551"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <connections>
                             <outlet property="dataSource" destination="pEE-Ob-lyd" id="Ngk-8P-HKu"/>
@@ -73,6 +77,7 @@
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="2cU-1T-ab4" customClass="TPKeyboardAvoidingCollectionView">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="551"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="DdR-bh-XrQ">
                             <size key="itemSize" width="180" height="40"/>
@@ -82,7 +87,7 @@
                         </collectionViewFlowLayout>
                         <cells>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="Cell" id="09N-1j-am2" customClass="TPKACollectionViewControllerCell">
-                                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                <rect key="frame" x="0.0" y="0.0" width="180" height="40"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                     <rect key="frame" x="0.0" y="0.0" width="180" height="40"/>
@@ -90,21 +95,25 @@
                                     <subviews>
                                         <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="AlF-cg-smg">
                                             <rect key="frame" x="96" y="5" width="76" height="30"/>
+                                            <animations/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <textInputTraits key="textInputTraits"/>
                                         </textField>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fxd-1t-Dug">
                                             <rect key="frame" x="8" y="9" width="80" height="21"/>
+                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="width" priority="750" constant="80" id="Nk8-YF-zCy"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
+                                    <animations/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 </view>
+                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="centerY" secondItem="Fxd-1t-Dug" secondAttribute="centerY" constant="0.5" id="95S-oP-X1S"/>
                                     <constraint firstItem="AlF-cg-smg" firstAttribute="leading" secondItem="Fxd-1t-Dug" secondAttribute="trailing" constant="8" id="9zS-zl-it9"/>
@@ -130,6 +139,78 @@
             </objects>
             <point key="canvasLocation" x="752" y="1022"/>
         </scene>
+        <!--Tall Text View-->
+        <scene sceneID="bN2-HK-E1H">
+            <objects>
+                <viewController id="DFn-8C-I7p" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="kht-OZ-f1d"/>
+                        <viewControllerLayoutGuide type="bottom" id="ow9-h5-rGL"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="gHh-GP-VLb">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="RlO-8I-qch" customClass="TPKeyboardAvoidingScrollView">
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="551"/>
+                                <subviews>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Oxp-Kg-Kvn">
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="1520"/>
+                                        <animations/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1520" id="nfg-yS-mgG"/>
+                                        </constraints>
+                                        <mutableString key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.
+
+
+
+Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.
+
+
+Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.
+
+
+Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.
+
+
+Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.
+
+
+Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.
+
+
+Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.
+</mutableString>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    </textView>
+                                </subviews>
+                                <animations/>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="Oxp-Kg-Kvn" secondAttribute="bottom" id="Av5-IP-v1v"/>
+                                    <constraint firstAttribute="trailing" secondItem="Oxp-Kg-Kvn" secondAttribute="trailing" id="C5r-1z-omG"/>
+                                    <constraint firstItem="Oxp-Kg-Kvn" firstAttribute="leading" secondItem="RlO-8I-qch" secondAttribute="leading" id="LpK-9V-A8k"/>
+                                    <constraint firstItem="Oxp-Kg-Kvn" firstAttribute="width" secondItem="RlO-8I-qch" secondAttribute="width" id="fVd-OW-9KU"/>
+                                    <constraint firstItem="Oxp-Kg-Kvn" firstAttribute="top" secondItem="RlO-8I-qch" secondAttribute="top" id="zQl-ej-lne"/>
+                                </constraints>
+                            </scrollView>
+                        </subviews>
+                        <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="ow9-h5-rGL" firstAttribute="top" secondItem="RlO-8I-qch" secondAttribute="bottom" id="5ad-Jl-zmE"/>
+                            <constraint firstItem="RlO-8I-qch" firstAttribute="leading" secondItem="gHh-GP-VLb" secondAttribute="leadingMargin" constant="-20" id="AzP-ly-eUF"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="RlO-8I-qch" secondAttribute="trailing" constant="-20" id="MzK-Kb-qlr"/>
+                            <constraint firstItem="RlO-8I-qch" firstAttribute="top" secondItem="kht-OZ-f1d" secondAttribute="bottom" constant="-20" id="gjB-pm-9Ow"/>
+                        </constraints>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Tall Text View" id="fb4-aT-QQj"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="OMS-cm-v21" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="752" y="1716"/>
+        </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="yl2-sM-qoP">
             <objects>
@@ -138,12 +219,14 @@
                     <tabBar key="tabBar" contentMode="scaleToFill" id="W28-zg-YXA">
                         <rect key="frame" x="0.0" y="975" width="768" height="49"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <animations/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     </tabBar>
                     <connections>
                         <segue destination="9pv-A4-QxB" kind="relationship" relationship="viewControllers" id="u7Y-xg-7CH"/>
                         <segue destination="pEE-Ob-lyd" kind="relationship" relationship="viewControllers" id="fDP-Lv-Sem"/>
                         <segue destination="q15-mF-pHj" kind="relationship" relationship="viewControllers" id="AtV-gv-0j1"/>
+                        <segue destination="DFn-8C-I7p" kind="relationship" relationship="viewControllers" id="5d7-rU-T87"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HuB-VB-40B" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
When the keyboard frame changes, TPKeyboardAvoiding attempts to center the first responder view in the visible space above the keyboard. This results in a jarring change in scroll position (see the "before" video below) in certain circumstances (for example: an auto-growing text view). I believe that a better approach is to, instead of centering the first responder view, center the cursor (when possible).

This is slightly challenging because the cursor is not accurate for a UITextView first enters its editing state. Accordingly, you'll see in my change that I've delayed the initial `contentOffset` adjustment due to a changing keyboard frame until a future runloop. I'm not entirely happy with this approach because of the natural hand-wavy nature of delaying to future run-loops. In addition, I found that a simple `dispatch_async()` was not sufficient to ensure that the UITextView's actual cursor position is measured, so I was forced to resort to a `dispatch_after(0.01 seconds)`, which is an even-less precise method of targeting a future run-loop in which the text view's cursor will be set. I'm hopeful the there exists a better method to deterministically target the correct run-loop that I haven't yet tried.

For reference, I've added a tab to the example project to demonstrate a non-scrolling UITextView whose height is much larger than the 

_Before my change:_
http://cl.ly/2Y3l0S3X001A/tall_text_view_demonstration_before.mov

_After my change:_
http://cl.ly/0p343Y2E0R2k/tall_text_view_demonstration_after.mov

Warnings:
* I've only tested this on iOS 9.
* My testing, though thorough for my own limited use cases of the `TPKeyboardAvoiding` library, is by no means globally thorough.
* This hasn't yet been used in production code.
* I couldn't find a great way to integrate this into the sample project without creating another tab. And when I did so, I didn't have an icon for the tab that matched the existing icon set. Sorry!