### PR TITLE
fix the issue that origin contentInset of table view will be overrided

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -93,10 +93,11 @@ static const int kStateKey;
         [UIView setAnimationCurve:[[[notification userInfo] objectForKey:UIKeyboardAnimationCurveUserInfoKey] intValue]];
         [UIView setAnimationDuration:[[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue]];
         
-        self.contentInset = [self TPKeyboardAvoiding_contentInsetForKeyboard];
-        
         UIView *firstResponder = [self TPKeyboardAvoiding_findFirstResponderBeneathView:self];
         if ( firstResponder ) {
+            
+            self.contentInset = [self TPKeyboardAvoiding_contentInsetForKeyboard];
+            
             CGFloat viewableHeight = self.bounds.size.height - self.contentInset.top - self.contentInset.bottom;
             [self setContentOffset:CGPointMake(self.contentOffset.x,
                                                [self TPKeyboardAvoiding_idealOffsetForView:firstResponder


### PR DESCRIPTION
**Test Environment**

iOS 10.0.2

Xcode 8.0

**Problem:**

After call resignFirstResponder on a TextField programmatically among a table view cell when the TextField is focused, iOS will trigger TPKeyboardAvoiding_keyboardWillShow again before TPKeyboardAvoiding_keyboardWillHide. But there is GCD delay in the method TPKeyboardAvoiding_keyboardWillShow, which results in that we set the contentInset of the table view after we restored its origin contentInset in the method TPKeyboardAvoiding_keyboardWillHide.

**Analysis:**

To identify this case, we can simply check whether there is firstResponder underneath the table view before we set the contentInset of the table view. 

**Solution:**

Move line below after we checked the firstResponder underneath the tableview/collectionview/scrollview

`self.contentInset = [self TPKeyboardAvoiding_contentInsetForKeyboard];`
