### PR TITLE
Added missing awakeFromNib

### DIFF
--- a/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingCollectionView.m
@@ -37,6 +37,7 @@
 }
 
 -(void)awakeFromNib {
+    [super awakeFromNib];
     [self setup];
 }
 

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
@@ -29,6 +29,7 @@
 }
 
 -(void)awakeFromNib {
+    [super awakeFromNib];
     [self setup];
 }
 


### PR DESCRIPTION
Got warnings in Xcode for the missing [super awakeFromNib] calls . Maybe you want to merge the simple change?!