### PR TITLE
Fixed target method signature of setAnimationDidStopSelector

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -121,8 +121,8 @@ static const int kStateKey;
     self.keyboardAvoidingState.keyboardAnimationInProgress = true;
 }
 
-- (void)keyboardViewDisappear:(NSString *)animationID finished:(BOOL)finished context:(void *)context {
-    if (finished) {
+- (void)keyboardViewDisappear:(NSString *)animationID finished:(NSNumber *)finished context:(void *)context {
+    if (finished.boolValue) {
         self.keyboardAvoidingState.keyboardAnimationInProgress = false;
     }
 }


### PR DESCRIPTION
Commit Msg: Fixed setAnimationDidStopSelector target method signature, method call delivers NSNumber instead of Bool

setAnimationDidStopSelector expects a method of the form: `- (void)animationDidStop:(NSString *)animationID finished:(NSNumber *)finished context:(void *)context`
It was implemented with a Bool for the finished parameter which lead the if statement to always resolve to true.

Discovered with Xcode 9, using the Undefined Behavior checker.