### PR TITLE
Fixed crash on iOS 8

### DIFF
--- a/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
@@ -49,7 +49,10 @@
 }
 
 -(BOOL)hasAutomaticKeyboardAvoidingBehaviour {
-    if ( [self.delegate isKindOfClass:[UITableViewController class]] ) {
+    // As library supports versions of iOS prior to 9 and iOS 8 SDK provides delegate property as assign, trying to
+    // access delegate property here in case of delegate is already deallocated causes crash on iOS 8 and earlier.
+    if ( [[[UIDevice currentDevice] systemVersion] integerValue] >= 9
+        && [self.delegate isKindOfClass:[UITableViewController class]] ) {
         // Theory: Apps built using the iOS 8.3 SDK (probably: older SDKs not tested) seem to handle keyboard
         // avoiding automatically with UITableViewController. This doesn't seem to be documented anywhere
         // by Apple, so results obtained only empirically.


### PR DESCRIPTION
<img width="1025" alt="screen shot 2017-06-14 at 16 30 11" src="https://user-images.githubusercontent.com/713720/27135067-4246faae-5120-11e7-8a70-36112187880e.png">
<img width="984" alt="screen shot 2017-06-14 at 16 30 58" src="https://user-images.githubusercontent.com/713720/27135075-4880550a-5120-11e7-9c18-236e4bfadd60.png">
The library sometimes crashes on iOS 8. After investigation I figured out that it crashes because object in delegate property is an `NSZombie`. It appeared that delegate property was declared as assign in iOS 8 SDK therefore it's not nilled when delegate object is getting deallocated.