### PR TITLE
Fixed a warning on Xcode 9 by specify no parameter explicitly.

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -351,7 +351,7 @@ static const int kStateKey;
 
     __block CGFloat padding = 0.0;
 
-    void(^centerViewInViewableArea)()  = ^ {
+    void(^centerViewInViewableArea)(void)  = ^ {
         // Attempt to center the subview in the visible space
         padding = (viewAreaHeight - subviewRect.size.height) / 2;
 


### PR DESCRIPTION
On Xcode 9 we should specify `void` explicitly if there is no parameter. Reference [here](https://stackoverflow.com/a/44473380/1548523)