### PR TITLE
Remove XCode 9 warning.

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -351,7 +351,7 @@ static const int kStateKey;
 
     __block CGFloat padding = 0.0;
 
-    void(^centerViewInViewableArea)()  = ^ {
+    void(^centerViewInViewableArea)(void)  = ^ {
         // Attempt to center the subview in the visible space
         padding = (viewAreaHeight - subviewRect.size.height) / 2;
 


### PR DESCRIPTION
When declaring blocks with no parameters it is now heavily suggested that `void` be explicitly added. 