### PR TITLE
Prevent bottom content inset from being negative.

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -338,7 +338,7 @@ static const int kStateKey;
     TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
     UIEdgeInsets newInset = self.contentInset;
     CGRect keyboardRect = state.keyboardRect;
-    newInset.bottom = keyboardRect.size.height - MAX((CGRectGetMaxY(keyboardRect) - CGRectGetMaxY(self.bounds)), 0);
+    newInset.bottom = MAX(keyboardRect.size.height - MAX((CGRectGetMaxY(keyboardRect) - CGRectGetMaxY(self.bounds)), 0), 0);
     return newInset;
 }
 


### PR DESCRIPTION
On an iPad with a hardware keyboard and the shortcuts bar enabled:

If the scroll view has a bounds of:

CGRectMake(0, 138, 787,  327)

and the keyboard has a bounds of:

CGRectMake(0, 713, 1024, 55)

Then the bottom inset ended up being -107, which would make the bottom content of the scroll view inaccessible.