### PR TITLE
Fix content insets not always being updated for QuickType bar

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -52,16 +52,17 @@ static const int kStateKey;
     
     state.animationDuration = [[info objectForKey:kUIKeyboardAnimationDurationUserInfoKey] doubleValue];
 
-    CGRect keyboardRect = [self convertRect:[[info objectForKey:_UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
-    if (CGRectIsEmpty(keyboardRect)) {
+    CGRect beginKeyboardRect = [self convertRect:[[info objectForKey:_UIKeyboardFrameBeginUserInfoKey] CGRectValue] fromView:nil];
+    CGRect endKeyboardRect = [self convertRect:[[info objectForKey:_UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
+    if (CGRectIsEmpty(endKeyboardRect)) {
         return;
     }
     
-    if ( state.ignoringNotifications ) {
+    if ( CGRectEqualToRect(beginKeyboardRect, endKeyboardRect) && state.ignoringNotifications ) {
         return;
     }
 
-    state.keyboardRect = keyboardRect;
+    state.keyboardRect = endKeyboardRect;
 
     if ( !state.keyboardVisible ) {
         state.priorInset = self.contentInset;
@@ -128,14 +129,15 @@ static const int kStateKey;
 }
 
 - (void)TPKeyboardAvoiding_keyboardWillHide:(NSNotification*)notification {
-    CGRect keyboardRect = [self convertRect:[[[notification userInfo] objectForKey:_UIKeyboardFrameBeginUserInfoKey] CGRectValue] fromView:nil];
-    if (CGRectIsEmpty(keyboardRect) && !self.keyboardAvoidingState.keyboardAnimationInProgress) {
+    CGRect beginKeyboardRect = [self convertRect:[[[notification userInfo] objectForKey:_UIKeyboardFrameBeginUserInfoKey] CGRectValue] fromView:nil];
+    CGRect endKeyboardRect = [self convertRect:[[[notification userInfo] objectForKey:_UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
+    if (CGRectIsEmpty(beginKeyboardRect) && !self.keyboardAvoidingState.keyboardAnimationInProgress) {
         return;
     }
     
     TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
     
-    if ( state.ignoringNotifications ) {
+    if ( CGRectEqualToRect(beginKeyboardRect, endKeyboardRect) && state.ignoringNotifications ) {
         return;
     }
     


### PR DESCRIPTION
Fixes an issue where scrolling to the next field would not update the content insets to include the QuickType bar if it appears.  This was brought about by the iOS 9 `ignoringNotifications` workaround.

Example:

1) Select a `UITextField` with no autocorrect/QuickType displayed.
2) Select another `UITextField` with QuickType displayed.
3) `contentInsets` are not updated, so anything at the bottom of the content view will be covered by the QuickType bar.

The implemented solution is to only check `ignoringNotifications` if the begin and end keyboard frames are the same.