### PR TITLE
customize module map

### DIFF
--- a/TPKeyboardAvoiding/include/module.modulemap
+++ b/TPKeyboardAvoiding/include/module.modulemap
@@ -1,3 +1,8 @@
 module TPKeyboardAvoiding {
+    header "../TPKeyboardAvoidingCollectionView.h"
+    header "../TPKeyboardAvoidingScrollView.h"
+    header "../TPKeyboardAvoidingTableView.h"
+    header "../UIScrollView+TPKeyboardAvoidingAdditions.h"
+
     export *
 }


### PR DESCRIPTION
Fix headers not exposed : https://github.com/michaeltyson/TPKeyboardAvoiding/issues/285